### PR TITLE
Remove return type from Ability::execute()

### DIFF
--- a/src/Abilities/Ability.php
+++ b/src/Abilities/Ability.php
@@ -42,7 +42,7 @@ abstract class Ability
      *
      * @param  array<string, mixed>  $input
      */
-    abstract public function execute(array $input): mixed;
+    abstract public function execute(array $input);
 
     /**
      * Determine whether the current user has permission to execute the ability.


### PR DESCRIPTION
Allow developers to declare their own return type when extending the Ability class instead of being locked into `mixed`.